### PR TITLE
Fix log handler early use of send_whatsapp_message

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ class WhatsAppLogHandler(logging.Handler):
         try:
             log_entry = self.format(record)
             # Only send to WhatsApp if LOG_RECIPIENT is set and not empty
-            if LOG_RECIPIENT:
+            if LOG_RECIPIENT and "send_whatsapp_message" in globals():
                 send_whatsapp_message(LOG_RECIPIENT, f"[LOG] {log_entry}")
         except Exception as e:
             # Fallback to file logging if WhatsApp fails


### PR DESCRIPTION
## Summary
- avoid NameError in WhatsApp log handler when module imports before `send_whatsapp_message` is defined

## Testing
- `python -m py_compile app.py scraper.py test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6f224de8832cab04aad45a68b16e