### PR TITLE
Improve scraping via Next.js data

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -620,23 +620,29 @@ class D2PlaceScraper:
 
     def scrape_shopping(self):
         url = f"{self.base_url}/shops/SHOP"
-        self.load_page(url, wait_selector="div.shop_shopListContainer__H9001")
-        card_elems = self.driver.find_elements(
-            By.CSS_SELECTOR, "div.shop_shopBlockContainer__ALRJK.cursor-pointer"
-        )
+        blob = next_blob(url, self.headers)
+        shops = blob.get("props", {}).get("pageProps", {}).get("shops", [])
 
-        for card in card_elems:
-            try:
-                item = self._card_to_item(card)
-                if item["detail_url"]:
-                    item |= self._harvest_detail(item["detail_url"])
-                    for k in ("phone", "opening_hours", "facebook", "instagram", "website"):
-                        item.setdefault(k, "")
-                self.data["shopping"].append(item)
-            except Exception as e:
-                logger.error(f"[SHOPPING] card parse failed: {e}")
+        for shop in shops:
+            item = {
+                "name":     shop.get("name"),
+                "location": shop.get("location"),
+                "detail_url": f"{self.base_url}/shops/{shop['slug']}",
+                **{k: shop.get("meta", {}).get(k, "") for k in ("tel", "openingHours", "facebook", "instagram", "website")}
+            }
 
-        logger.info("Shopping scraped → %d entries", len(self.data["shopping"]))
+            if not any(item[k] for k in ("openingHours", "facebook", "instagram", "website")):
+                sub = next_blob(item["detail_url"], self.headers)
+                meta = (sub.get("props", {}).get("pageProps", {}).get("meta", {}))
+                for k, v in meta.items():
+                    if v and not item.get(k):
+                        item[k] = v
+
+            item["opening_hours"] = item.pop("openingHours", "")
+            item["phone"] = item.pop("tel", "")
+            self.data["shopping"].append(item)
+
+        logger.info("Shopping scraped → %d entries (no clicks!)", len(self.data["shopping"]))
 
     def scrape_events(self):
         url = f"{self.base_url}/events/ALL"
@@ -663,23 +669,29 @@ class D2PlaceScraper:
 
     def scrape_play(self):
         url = f"{self.base_url}/shops/PLAY"
-        self.load_page(url, wait_selector="div.shop_shopListContainer__H9001")
-        card_elems = self.driver.find_elements(
-            By.CSS_SELECTOR, "div.shop_shopBlockContainer__ALRJK.cursor-pointer"
-        )
+        blob = next_blob(url, self.headers)
+        shops = blob.get("props", {}).get("pageProps", {}).get("shops", [])
 
-        for card in card_elems:
-            try:
-                item = self._card_to_item(card)
-                if item["detail_url"]:
-                    item |= self._harvest_detail(item["detail_url"])
-                    for k in ("phone", "opening_hours", "facebook", "instagram", "website"):
-                        item.setdefault(k, "")
-                self.data["play"].append(item)
-            except Exception as e:
-                logger.error(f"[PLAY] card parse failed: {e}")
+        for shop in shops:
+            item = {
+                "name":     shop.get("name"),
+                "location": shop.get("location"),
+                "detail_url": f"{self.base_url}/shops/{shop['slug']}",
+                **{k: shop.get("meta", {}).get(k, "") for k in ("tel", "openingHours", "facebook", "instagram", "website")}
+            }
 
-        logger.info("Play scraped → %d entries", len(self.data["play"]))
+            if not any(item[k] for k in ("openingHours", "facebook", "instagram", "website")):
+                sub = next_blob(item["detail_url"], self.headers)
+                meta = (sub.get("props", {}).get("pageProps", {}).get("meta", {}))
+                for k, v in meta.items():
+                    if v and not item.get(k):
+                        item[k] = v
+
+            item["opening_hours"] = item.pop("openingHours", "")
+            item["phone"] = item.pop("tel", "")
+            self.data["play"].append(item)
+
+        logger.info("Play scraped → %d entries (no clicks!)", len(self.data["play"]))
 
     # ================== Facebook Page ==================
     def scrape_facebook_page(self, shop, fb_url):


### PR DESCRIPTION
## Summary
- fetch shop listings using the Next.js JSON blob instead of Selenium clicks
- same approach for "play" shops
- ensure file ends with a newline

## Testing
- `python -m py_compile scraper.py`
- `pip install serpapi` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684f70859a98832c92cc533d6ec38623