### PR TITLE
Scrape shops via GraphQL

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -53,6 +53,22 @@ def _extract_next_data(html_text: str) -> dict | None:
         return None
 
 
+def gql(query: str, variables: dict | None = None, headers: dict | None = None):
+    """Helper to POST a GraphQL query and return JSON."""
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    h = {"Content-Type": "application/json"}
+    if headers:
+        h.update(headers)
+    r = requests.post("https://www.d2place.com/graphql", headers=h, json=payload, timeout=15)
+    r.raise_for_status()
+    data = r.json()
+    if "errors" in data:
+        raise RuntimeError(data["errors"])
+    return data.get("data", {})
+
+
 class D2PlaceScraper:
     def __init__(self):
         self.base_url = "https://www.d2place.com"
@@ -589,54 +605,69 @@ class D2PlaceScraper:
             return None
 
     def scrape_dining(self):
-        url = f"{self.base_url}/shops/DINING"
-        blob = next_blob(url, self.headers)
-        shops = blob.get("props", {}).get("pageProps", {}).get("shops", [])
-        for shop in shops:
-            item = {
-                "name":     shop.get("name"),
-                "location": shop.get("location"),
-                "detail_url": f"{self.base_url}/shops/{shop['slug']}",
-                **{k: shop.get("meta", {}).get(k, "") for k in
-                ("tel", "openingHours", "facebook", "instagram", "website")}
-            }
+        cats = gql("{findManyShopCategory(where:{categoryType:{equals:DINING}}){id}}")
+        for c in cats.get("findManyShopCategory", []):
+            shops = gql(
+                """
+                query($cid:Int!){
+                    findManyShop(where:{shopCategoryId:{equals:$cid}}, take:1000){
+                        nameEn nameTc addressEn addressTc phoneNumber
+                        displayOpeningHoursEn displayOpeningHoursTc
+                        facebookUrl instagramUrl websiteUrl passcode
+                    }
+                }
+                """,
+                {"cid": c["id"]},
+                headers=self.headers,
+            ).get("findManyShop", [])
 
-            # if hours or socials still blank → fetch the shop page once
-            if not any(item[k] for k in ("openingHours", "facebook", "instagram", "website")):
-                sub = next_blob(item["detail_url"], self.headers)
-                meta = (sub.get("props", {}).get("pageProps", {})
-                            .get("meta", {}))
-                for k,v in meta.items():
-                    if v and not item.get(k):
-                        item[k] = v
+            for shop in shops:
+                item = {
+                    "name": shop.get("nameEn") or shop.get("nameTc", ""),
+                    "location": shop.get("addressEn") or shop.get("addressTc", ""),
+                    "detail_url": f"{self.base_url}/shops/{shop['passcode']}",
+                    "phone": shop.get("phoneNumber", ""),
+                    "opening_hours": shop.get("displayOpeningHoursEn") or shop.get("displayOpeningHoursTc", ""),
+                    "facebook": shop.get("facebookUrl", ""),
+                    "instagram": shop.get("instagramUrl", ""),
+                    "website": shop.get("websiteUrl", ""),
+                }
+                self.data["dining"].append(item)
 
-            # rename keys to your existing schema
-            item["opening_hours"] = item.pop("openingHours", "")
-            item["phone"]         = item.pop("tel", "")
-            self.data["dining"].append(item)
-
-        logger.info("Dining scraped → %d entries (no clicks!)", len(self.data["dining"]))
+        logger.info("Dining scraped via GraphQL → %d entries", len(self.data["dining"]))
 
 
     def scrape_shopping(self):
-        url = f"{self.base_url}/shops/SHOP"
-        self.load_page(url, wait_selector="div.shop_shopListContainer__H9001")
-        card_elems = self.driver.find_elements(
-            By.CSS_SELECTOR, "div.shop_shopBlockContainer__ALRJK.cursor-pointer"
-        )
+        cats = gql("{findManyShopCategory(where:{categoryType:{equals:SHOP}}){id}}")
+        for c in cats.get("findManyShopCategory", []):
+            shops = gql(
+                """
+                query($cid:Int!){
+                    findManyShop(where:{shopCategoryId:{equals:$cid}}, take:1000){
+                        nameEn nameTc addressEn addressTc phoneNumber
+                        displayOpeningHoursEn displayOpeningHoursTc
+                        facebookUrl instagramUrl websiteUrl passcode
+                    }
+                }
+                """,
+                {"cid": c["id"]},
+                headers=self.headers,
+            ).get("findManyShop", [])
 
-        for card in card_elems:
-            try:
-                item = self._card_to_item(card)
-                if item["detail_url"]:
-                    item |= self._harvest_detail(item["detail_url"])
-                    for k in ("phone", "opening_hours", "facebook", "instagram", "website"):
-                        item.setdefault(k, "")
+            for shop in shops:
+                item = {
+                    "name": shop.get("nameEn") or shop.get("nameTc", ""),
+                    "location": shop.get("addressEn") or shop.get("addressTc", ""),
+                    "detail_url": f"{self.base_url}/shops/{shop['passcode']}",
+                    "phone": shop.get("phoneNumber", ""),
+                    "opening_hours": shop.get("displayOpeningHoursEn") or shop.get("displayOpeningHoursTc", ""),
+                    "facebook": shop.get("facebookUrl", ""),
+                    "instagram": shop.get("instagramUrl", ""),
+                    "website": shop.get("websiteUrl", ""),
+                }
                 self.data["shopping"].append(item)
-            except Exception as e:
-                logger.error(f"[SHOPPING] card parse failed: {e}")
 
-        logger.info("Shopping scraped → %d entries", len(self.data["shopping"]))
+        logger.info("Shopping scraped via GraphQL → %d entries", len(self.data["shopping"]))
 
     def scrape_events(self):
         url = f"{self.base_url}/events/ALL"
@@ -662,24 +693,36 @@ class D2PlaceScraper:
         logger.info("Events scraped → %d entries", len(self.data["events"]))
 
     def scrape_play(self):
-        url = f"{self.base_url}/shops/PLAY"
-        self.load_page(url, wait_selector="div.shop_shopListContainer__H9001")
-        card_elems = self.driver.find_elements(
-            By.CSS_SELECTOR, "div.shop_shopBlockContainer__ALRJK.cursor-pointer"
-        )
+        cats = gql("{findManyShopCategory(where:{categoryType:{equals:PLAY}}){id}}")
+        for c in cats.get("findManyShopCategory", []):
+            shops = gql(
+                """
+                query($cid:Int!){
+                    findManyShop(where:{shopCategoryId:{equals:$cid}}, take:1000){
+                        nameEn nameTc addressEn addressTc phoneNumber
+                        displayOpeningHoursEn displayOpeningHoursTc
+                        facebookUrl instagramUrl websiteUrl passcode
+                    }
+                }
+                """,
+                {"cid": c["id"]},
+                headers=self.headers,
+            ).get("findManyShop", [])
 
-        for card in card_elems:
-            try:
-                item = self._card_to_item(card)
-                if item["detail_url"]:
-                    item |= self._harvest_detail(item["detail_url"])
-                    for k in ("phone", "opening_hours", "facebook", "instagram", "website"):
-                        item.setdefault(k, "")
+            for shop in shops:
+                item = {
+                    "name": shop.get("nameEn") or shop.get("nameTc", ""),
+                    "location": shop.get("addressEn") or shop.get("addressTc", ""),
+                    "detail_url": f"{self.base_url}/shops/{shop['passcode']}",
+                    "phone": shop.get("phoneNumber", ""),
+                    "opening_hours": shop.get("displayOpeningHoursEn") or shop.get("displayOpeningHoursTc", ""),
+                    "facebook": shop.get("facebookUrl", ""),
+                    "instagram": shop.get("instagramUrl", ""),
+                    "website": shop.get("websiteUrl", ""),
+                }
                 self.data["play"].append(item)
-            except Exception as e:
-                logger.error(f"[PLAY] card parse failed: {e}")
 
-        logger.info("Play scraped → %d entries", len(self.data["play"]))
+        logger.info("Play scraped via GraphQL → %d entries", len(self.data["play"]))
 
     # ================== Facebook Page ==================
     def scrape_facebook_page(self, shop, fb_url):


### PR DESCRIPTION
## Summary
- switch dining, shopping and play scrapers to use the public GraphQL endpoint
- add helper `gql()` for GraphQL requests

## Testing
- `python -m py_compile scraper.py`
- `pip install serpapi` *(succeeds)*
- `echo 'exit' | python test.py` *(interactive test exits immediately)*

------
https://chatgpt.com/codex/tasks/task_e_684f70859a98832c92cc533d6ec38623