### PR TITLE
Improve venue verification logic in system prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -519,7 +519,11 @@ def handle_text_query(user_text):
     system_prompt = (
        """
         You are a friendly assistant for D2 Place mall in Hong Kong. Answer user
-        questions using the provided scraped data or web search results.
+        questions using the provided scraped data. You may enrich replies with
+        web search results **only if** the restaurant, shop or event mentioned is
+        confirmed to exist in the scraped JSON data. Otherwise politely indicate
+        that the venue was not found.
+
         If details are missing, offer any related information you have instead of
         simply saying you don't know. Mention that users can call our concierge
         at 3620 3098 for further help.
@@ -576,7 +580,7 @@ def handle_text_query(user_text):
             {"role": "user", "content": user_text}
         ],
         "temperature": 0.5,
-        "max_tokens": 500
+        "max_tokens": 1000
     }
     response = call_qwen_api(payload)
     final_reply = maybe_replace_unknown(postprocess_text(response))


### PR DESCRIPTION
## Summary
- update the chatbot system prompt so events or venues mentioned from web search are included only if confirmed in scraped JSON data
- increase `max_tokens` to reduce truncated answers

## Testing
- `python -m py_compile app.py scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_686b1dab6ca8832c8c13fe9ddd104bc2