### PR TITLE
Only send parking photos for general parking

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository contains a Flask application that powers a WhatsApp chatbot for 
    - `WHATSAPP_TOKEN` – WhatsApp Cloud API access token
    - `PHONE_NUMBER_ID` – your WhatsApp phone number ID
    - `LOG_RECIPIENT` – phone number where log messages should be sent
+   - `PUBLIC_URL` – base URL of your Flask server used for serving images
 
 ## Running the bot
 


### PR DESCRIPTION
## Summary
- keep 60‑second timeout for Qwen API calls
- drop promotion image response

## Testing
- `python -m py_compile app.py`
- `python -m flask --app app routes | head`


------
https://chatgpt.com/codex/tasks/task_e_6874c7732704832cb0b1bba182bcd685