### PR TITLE
Improve parking images and strip phone numbers

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,22 @@ import time
 from urllib.parse import urljoin
 from bs4 import BeautifulSoup
 
+PHONE_REGEX = re.compile(r"(?:\+?852[-\s]?)?\d{4}[-\s]?\d{4}")
+
+def remove_phone_numbers(text: str) -> str:
+    """Return ``text`` with Hong Kong style phone numbers removed."""
+    return PHONE_REGEX.sub("", text)
+
+def strip_phone_numbers(obj):
+    """Recursively remove phone numbers from all string values in ``obj``."""
+    if isinstance(obj, dict):
+        return {k: strip_phone_numbers(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [strip_phone_numbers(x) for x in obj]
+    if isinstance(obj, str):
+        return remove_phone_numbers(obj)
+    return obj
+
 load_dotenv()
 
 # Environment variables
@@ -91,7 +107,8 @@ _executor = ThreadPoolExecutor(max_workers=20)
 
 try:
     with open("d2place_data.json", "r", encoding="utf-8") as f:
-        CACHED_DATA = json.load(f)
+        raw_data = json.load(f)
+    CACHED_DATA = strip_phone_numbers(raw_data)
     logger.info("Loaded scraped data into CACHED_DATA")
 except Exception as e:
     logger.error("Failed to load d2place_data.json into cache: %s", e)
@@ -567,7 +584,7 @@ def should_send_image(text: str) -> bool:
 def is_parking_query(text: str) -> bool:
     """Return True if the user is asking about parking."""
     lowered = text.lower()
-    keywords = ["parking", "car park", "泊車", "停車", "車位"]
+    keywords = ["parking", "car park", "carpark", "car-park", "泊車", "停車", "停車場", "車位"]
     return any(k in lowered for k in keywords)
 
 
@@ -674,7 +691,8 @@ def handle_text_query(user_text):
         Keep all answers focused on D2 Place or the LAWSGROUP community only.
 
         If details are missing, offer any related information you have instead of
-        simply saying you don't know. Do not mention any concierge phone number.
+        simply saying you don't know. Do not mention any concierge phone number
+        and do not share or provide any phone numbers in your replies.
         Avoid using tables. Format each venue with its name, address, business
         hour and D2 Place page, separated by blank lines. Maintain a warm tone.
         """
@@ -735,6 +753,7 @@ def handle_text_query(user_text):
     }
     response = call_qwen_api(payload)
     final_reply = maybe_replace_unknown(postprocess_text(response))
+    final_reply = remove_phone_numbers(final_reply)
     promo = follow_up_promotion(user_text)
     if promo:
         final_reply += "\n\n" + promo
@@ -1062,7 +1081,7 @@ def process_message(msg):
         )
         send_whatsapp_message(from_user, note)
 
-        if msg_type == 'text' and is_parking_query(inbound_text) and not is_parking_promotion_query(inbound_text):
+        if msg_type == 'text' and is_parking_query(inbound_text):
             send_parking_images(from_user)
 
         if msg_type == 'text':


### PR DESCRIPTION
## Summary
- instruct the model not to share phone numbers
- send parking promo images on any parking query

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6874cf987714832c9fa70b69bb120ea5