### PR TITLE
Fix PUBLIC_URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ This repository contains a Flask application that powers a WhatsApp chatbot for 
    - `LOG_RECIPIENT` – phone number where log messages should be sent
   - `PUBLIC_URL` – base URL of your Flask server used for serving images.
     This must be a publicly reachable URL (e.g. an ngrok tunnel) so WhatsApp
-    can download files from the `/assets` path. The app exposes this route
-    using `@app.route('/assets/<filename>')`, serving files from the local
-    `Assets` folder.
+    can download files from the `/Assets` path. The app exposes this route
+    using `@app.route('/Assets/<path:filename>')`, serving files from the local
+    `Assets` folder. Set this to the public domain of your server (for example
+    `https://chatbot.d2place.com`).
 
 ## Running the bot
 

--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ VERIFY_TOKEN = os.environ.get('VERIFY_TOKEN')
 WHATSAPP_TOKEN = os.environ.get('WHATSAPP_TOKEN')
 PHONE_NUMBER_ID = os.environ.get('PHONE_NUMBER_ID')
 LOG_RECIPIENT = os.environ.get('LOG_RECIPIENT')
-PUBLIC_URL = "https://chatbot.d2place.com"
+PUBLIC_URL = os.environ.get("PUBLIC_URL", "https://chatbot.d2place.com")
 BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 # Use a fixed model so the chatbot always calls the same Qwen version
 QWEN_MODEL = "qwen-plus"
@@ -594,7 +594,10 @@ def is_parking_query(text: str) -> bool:
     """Return True if the user is asking about parking."""
     lowered = text.lower()
     keywords = ["parking", "car park", "carpark", "car-park", "泊車", "停車", "停車場", "車位"]
-    return any(k in lowered for k in keywords)
+    for k in keywords:
+        if k in lowered or fuzz.partial_ratio(lowered, k) >= FUZZY_THRESHOLD:
+            return True
+    return False
 
 
 def is_parking_promotion_query(text: str) -> bool:


### PR DESCRIPTION
## Summary
- fix PUBLIC_URL to read from environment with a default
- fuzzy match "parking" requests so small typos like "pakring" still trigger image sending
- document that PUBLIC_URL must point to a public /Assets URL

## Testing
- `python -m py_compile app.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874ea225e74832cafb72906d83b142c