### PR TITLE
Fix shop URL slugging

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -644,12 +644,80 @@ class D2PlaceScraper:
             return None
 
     def slugify(self, text: str) -> str:
-        """Return *text* converted to a URL slug."""
+        """Return *text* converted to a URL slug.
+
+        The original implementation stripped any non\-ASCII characters which
+        meant Chinese shop names resulted in empty slugs.  This version keeps
+        the simple replacement logic for ASCII strings but if the resulting slug
+        is empty it falls back to keeping the original characters and only
+        replacing whitespace with hyphens.  This still yields a usable slug for
+        URLs that already expect the shop's passcode or alias.
+        """
         if not text:
             return ""
+
         slug = re.sub(r"[^A-Za-z0-9]+", "-", text).strip("-")
         slug = re.sub(r"-+", "-", slug)
+        if slug:
+            return slug
+
+        # Fallback: allow any word characters (e.g. Chinese) and hyphenate
+        slug = re.sub(r"\W+", "-", text, flags=re.UNICODE).strip("-")
+        slug = re.sub(r"-+", "-", slug)
         return slug
+
+    def _lookup_alias(self, shop: dict) -> dict:
+        """Query GraphQL to find a shop's alias and passcode by name."""
+        name_en = shop.get("nameEn") or ""
+        name_tc = shop.get("nameTc") or ""
+        key = (name_en, name_tc)
+        if key in getattr(self, "_alias_cache", {}):
+            return self._alias_cache[key]
+
+        query = """
+        query($en:String,$tc:String){
+            findFirstShop(where:{OR:[{nameEn:{equals:$en}},{nameTc:{equals:$tc}}]}){
+                alias
+                passcode
+            }
+        }
+        """
+        try:
+            data = gql(query, {"en": name_en, "tc": name_tc}, headers=self.headers)
+            node = data.get("findFirstShop") or {}
+            alias = node.get("alias", "")
+            passcode = node.get("passcode", "")
+        except Exception:
+            alias = passcode = ""
+
+        if not hasattr(self, "_alias_cache"):
+            self._alias_cache = {}
+        self._alias_cache[key] = {"alias": alias, "passcode": passcode}
+        return self._alias_cache[key]
+
+    def shop_slug(self, shop: dict) -> str:
+        """Return the best slug for a shop using alias or passcode when possible."""
+        alias = shop.get("alias")
+        passcode = shop.get("passcode")
+
+        if alias:
+            return alias
+
+        extra = self._lookup_alias(shop)
+        alias = extra.get("alias")
+        if alias:
+            return alias
+
+        if passcode and not str(passcode).isdigit():
+            return str(passcode)
+
+        if not passcode:
+            passcode = extra.get("passcode")
+            if passcode and not str(passcode).isdigit():
+                return str(passcode)
+
+        slug_src = shop.get("nameEn") or shop.get("nameTc", "")
+        return self.slugify(slug_src)
 
     def scrape_dining(self):
         cats = gql("{findManyShopCategory(where:{categoryType:{equals:DINING}}){id}}")
@@ -658,7 +726,7 @@ class D2PlaceScraper:
                 """
                 query($cid:Int!){
                     findManyShop(where:{shopCategoryId:{equals:$cid}}, take:1000){
-                        nameEn nameTc addressEn addressTc phoneNumber
+                        nameEn nameTc alias addressEn addressTc phoneNumber
                         displayOpeningHoursEn displayOpeningHoursTc
                         facebookUrl instagramUrl websiteUrl passcode
                     }
@@ -670,10 +738,11 @@ class D2PlaceScraper:
 
         for shop in shops:
             name_en = shop.get("nameEn") or shop.get("nameTc", "")
+            slug = self.shop_slug(shop)
             item = {
                 "name": name_en,
                 "location": shop.get("addressEn") or shop.get("addressTc", ""),
-                "detail_url": f"{self.base_url}/shops/DINING/{self.slugify(name_en)}",
+                "detail_url": f"{self.base_url}/shops/DINING/{slug}",
                 "phone": shop.get("phoneNumber", ""),
                 "opening_hours": shop.get("displayOpeningHoursEn") or shop.get("displayOpeningHoursTc", ""),
                 "facebook": shop.get("facebookUrl", ""),
@@ -692,7 +761,7 @@ class D2PlaceScraper:
                 """
                 query($cid:Int!){
                     findManyShop(where:{shopCategoryId:{equals:$cid}}, take:1000){
-                        nameEn nameTc addressEn addressTc phoneNumber
+                        nameEn nameTc alias addressEn addressTc phoneNumber
                         displayOpeningHoursEn displayOpeningHoursTc
                         facebookUrl instagramUrl websiteUrl passcode
                     }
@@ -704,10 +773,11 @@ class D2PlaceScraper:
 
         for shop in shops:
             name_en = shop.get("nameEn") or shop.get("nameTc", "")
+            slug = self.shop_slug(shop)
             item = {
                 "name": name_en,
                 "location": shop.get("addressEn") or shop.get("addressTc", ""),
-                "detail_url": f"{self.base_url}/shops/SHOP/{self.slugify(name_en)}",
+                "detail_url": f"{self.base_url}/shops/SHOP/{slug}",
                 "phone": shop.get("phoneNumber", ""),
                 "opening_hours": shop.get("displayOpeningHoursEn") or shop.get("displayOpeningHoursTc", ""),
                 "facebook": shop.get("facebookUrl", ""),
@@ -769,7 +839,7 @@ class D2PlaceScraper:
                 """
                 query($cid:Int!){
                     findManyShop(where:{shopCategoryId:{equals:$cid}}, take:1000){
-                        nameEn nameTc addressEn addressTc phoneNumber
+                        nameEn nameTc alias addressEn addressTc phoneNumber
                         displayOpeningHoursEn displayOpeningHoursTc
                         facebookUrl instagramUrl websiteUrl passcode
                     }
@@ -781,10 +851,11 @@ class D2PlaceScraper:
 
             for shop in shops:
                 name_en = shop.get("nameEn") or shop.get("nameTc", "")
+                slug = self.shop_slug(shop)
                 item = {
                     "name": name_en,
                     "location": shop.get("addressEn") or shop.get("addressTc", ""),
-                    "detail_url": f"{self.base_url}/shops/PLAY/{self.slugify(name_en)}",
+                    "detail_url": f"{self.base_url}/shops/PLAY/{slug}",
                     "phone": shop.get("phoneNumber", ""),
                     "opening_hours": shop.get("displayOpeningHoursEn") or shop.get("displayOpeningHoursTc", ""),
                     "facebook": shop.get("facebookUrl", ""),


### PR DESCRIPTION
## Summary
- query each shop's alias and passcode from GraphQL
- cache alias lookups and prefer them to passcodes
- build shop detail URLs with the alias when available

## Testing
- `python -m py_compile scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_687e3b7a9514832c86770c05ff90c3ce