### PR TITLE
Change scraper schedule to daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ The file `scraper.py` fetches data from the D2 Place website and saves it to `d2
 ```bash
 python scraper.py
 ```
-The script also schedules a weekly run every Monday at 02:00 Hong Kong time when executed directly.
+The script also schedules a daily run every day at 02:00 Hong Kong time when executed directly.
+The Flask app reloads `d2place_data.json` at 03:00 so it can use the freshly scraped data without restarting.
 
 The JSON file contains a `manual_info` section where you can store custom notes.
 This portion of the file is preserved whenever the scraper runs, so feel free to

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from concurrent.futures import ThreadPoolExecutor
 import time
 from urllib.parse import urljoin
 from bs4 import BeautifulSoup
+from apscheduler.schedulers.background import BackgroundScheduler
 
 PHONE_REGEX = re.compile(r"(?:\+?852[-\s]?)?\d{4}[-\s]?\d{4}")
 EMAIL_REGEX = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
@@ -122,18 +123,35 @@ _CLEANUP_INTERVAL = timedelta(hours=1)  # Clean up old messages every hour
 # Allow more concurrent message processing to reduce queue delays
 _executor = ThreadPoolExecutor(max_workers=20)
 
-try:
-    with open("d2place_data.json", "r", encoding="utf-8") as f:
-        raw_data = json.load(f)
-    CACHED_DATA = strip_contact_info(raw_data)
-    logger.info("Loaded scraped data into CACHED_DATA")
-except Exception as e:
-    logger.error("Failed to load d2place_data.json into cache: %s", e)
-    CACHED_DATA = {}
+
+def load_scraped_data():
+    """Load d2place_data.json into the global cache."""
+    global CACHED_DATA, FULL_JSON_TEXT
+    try:
+        with open("d2place_data.json", "r", encoding="utf-8") as f:
+            raw_data = json.load(f)
+        CACHED_DATA = strip_contact_info(raw_data)
+        FULL_JSON_TEXT = json.dumps(CACHED_DATA, ensure_ascii=False)
+        logger.info("Reloaded scraped data into cache")
+    except Exception as e:
+        logger.error("Failed to load d2place_data.json into cache: %s", e)
+        CACHED_DATA = {}
+        FULL_JSON_TEXT = "{}"
 
 
-# Pre-serialize the full JSON once for LLM context
-FULL_JSON_TEXT = json.dumps(CACHED_DATA, ensure_ascii=False)
+# Initial load
+load_scraped_data()
+
+# Reload the scraped data daily at 03:00 HK time
+_reload_scheduler = BackgroundScheduler(timezone="Asia/Hong_Kong")
+_reload_scheduler.add_job(
+    load_scraped_data,
+    trigger="cron",
+    hour=3,
+    minute=0,
+    id="reload_scraped_data",
+)
+_reload_scheduler.start()
 
 
 def async_worker(fn):

--- a/scraper.py
+++ b/scraper.py
@@ -1053,17 +1053,16 @@ if __name__ == "__main__":
     
     scraper.scrape_all()
     
-    # run once a week: every Monday at 02:00
+    # run once a day at 02:00
     scheduler.add_job(
         scraper.scrape_all,
         trigger='cron',
-        day_of_week='mon',
         hour=2,
         minute=0,
-        id='weekly_d2_scrape'
+        id='daily_d2_scrape'
     )
 
-    logger.info("Starting weekly scraper job (every Monday at 02:00 HK time)")
+    logger.info("Starting daily scraper job (every day at 02:00 HK time)")
     try:
         scheduler.start()
     except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
## Summary
- run the scraper every day instead of weekly
- update README to document the new schedule
- reload scraped data in app.py daily so Flask uses fresh data without restart

## Testing
- `python -m py_compile scraper.py app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880b4f0d4b4832cac202d6ead44e8e2